### PR TITLE
feat(runtime): btoa api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "andromeda-core",
  "anyhow",
  "anymap",
+ "base64-simd",
  "nova_vm",
  "oxc-miette",
  "oxc_diagnostics",
@@ -177,6 +178,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
 dependencies = [
  "backtrace",
+]
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -764,6 +775,12 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
@@ -1605,6 +1622,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wasi"

--- a/examples/btoa.ts
+++ b/examples/btoa.ts
@@ -1,0 +1,5 @@
+const ok = "a";
+console.log("ok: ", btoa(ok)); // YQ==
+
+const notOK = "✓";
+console.log("notOK: ", btoa(notOK)); // error

--- a/namespace/mod.ts
+++ b/namespace/mod.ts
@@ -296,3 +296,12 @@ function alert(message: string) {
   internal_print(message + " [Enter]");
   Andromeda.stdin.readLine();
 }
+
+/**
+ * Takes the input data, in the form of a Unicode string containing only characters in the range U+0000 to U+00FF, 
+ * each representing a binary byte with values 0x00 to 0xFF respectively, and converts it to its base64 representation, 
+ * which it returns.
+ */
+function btoa(input: string): string {
+  return internal_btoa(input);
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,3 +16,4 @@ oxc-miette.workspace = true
 oxc_diagnostics.workspace = true
 serde.workspace = true
 url.workspace = true
+base64-simd = "0.8.0"

--- a/runtime/src/ext/mod.rs
+++ b/runtime/src/ext/mod.rs
@@ -3,9 +3,11 @@ mod fs;
 mod process;
 mod time;
 mod url;
+mod web;
 
 pub use console::*;
 pub use fs::*;
 pub use process::*;
 pub use time::*;
 pub use url::*;
+pub use web::*;

--- a/runtime/src/ext/web/mod.rs
+++ b/runtime/src/ext/web/mod.rs
@@ -1,0 +1,54 @@
+use andromeda_core::{Extension, ExtensionOp};
+use nova_vm::{
+    ecmascript::{
+        builtins::ArgumentsList,
+        execution::{agent::ExceptionType, Agent, JsResult},
+        types::Value,
+    },
+    engine::context::GcScope,
+};
+
+#[derive(Default)]
+pub struct WebExt;
+
+impl WebExt {
+    pub fn new_extension() -> Extension {
+        Extension {
+            name: "web",
+            ops: vec![ExtensionOp::new("internal_btoa", Self::internal_btoa, 1)],
+            storage: None,
+            files: vec![],
+        }
+    }
+
+    pub fn internal_btoa(
+        agent: &mut Agent,
+        _this: Value,
+        args: ArgumentsList,
+        mut gc: GcScope<'_, '_>,
+    ) -> JsResult<Value> {
+        let input = args.get(0).to_string(agent, gc.reborrow())?;
+        let rust_string = input.as_str(agent).to_string();
+        for c in rust_string.chars() {
+            if c as u32 > 0xFF {
+                // TODO: Returning an InvalidCharacterError is the correct behavior.
+                // ref: https://html.spec.whatwg.org/multipage/webappapis.html#atob
+                return Err(agent.throw_exception(ExceptionType::Error, format!(
+                    "InvalidCharacterError: The string to be encoded contains characters outside of the Latin1 range. Found: '{}'",
+                    c
+                ), gc.nogc()));
+            }
+        }
+        Ok(Self::forgiving_base64_encode(
+            agent,
+            rust_string.as_bytes(),
+            gc,
+        ))
+    }
+
+    /// See <https://infra.spec.whatwg.org/#forgiving-base64>
+    pub fn forgiving_base64_encode(agent: &mut Agent, s: &[u8], gc: GcScope<'_, '_>) -> Value {
+        let encoded_str = base64_simd::STANDARD.encode_to_string(s);
+        Value::from_string(agent, encoded_str, gc.nogc())
+    }
+}

--- a/runtime/src/recommended.rs
+++ b/runtime/src/recommended.rs
@@ -1,7 +1,7 @@
 use andromeda_core::{Extension, HostData};
 use nova_vm::ecmascript::execution::agent::{GcAgent, RealmRoot};
 
-use crate::{ConsoleExt, FsExt, ProcessExt, RuntimeMacroTask, TimeExt, URLExt};
+use crate::{ConsoleExt, FsExt, ProcessExt, RuntimeMacroTask, TimeExt, URLExt, WebExt};
 
 pub fn recommended_extensions() -> Vec<Extension> {
     vec![
@@ -10,6 +10,7 @@ pub fn recommended_extensions() -> Vec<Extension> {
         TimeExt::new_extension(),
         ProcessExt::new_extension(),
         URLExt::new_extension(),
+        WebExt::new_extension(),
     ]
 }
 

--- a/types/internals.d.ts
+++ b/types/internals.d.ts
@@ -92,3 +92,8 @@ declare function internal_url_parse(url: string, base: string): string;
  * The `internal_url_parse_no_base` function to parse a URL string without a base URL.
  */
 declare function internal_url_parse_no_base(url: string): string;
+
+/**
+ * The `internal_btoa` function encodes a string in base64.
+ */
+declare function internal_btoa(url: string): string;


### PR DESCRIPTION
I implemented [btoa](https://html.spec.whatwg.org/multipage/webappapis.html#dom-btoa).
I mainly referred to Deno while implementing it, so the structure of ext/web follows a similar pattern.
You can check the reference here: [Deno’s 05_base64.js](https://github.com/denoland/deno/blob/2212d7d814914e43f43dfd945ee24197f50fa6fa/ext/web/05_base64.js#L44-L59).

I was figuring things out as I went along, so the code might be a bit messy, but for now, it works in example/btoa.ts 👀