### PR TITLE
chore: update cargo version to 1.85 and edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["cli", "core", "runtime"]
 
 [workspace.package]
 authors = ["the Andromeda team"]
-edition = "2021"
+edition = "2024"
 license = "Mozilla Public License 2.0"
 repository = "https://github.com/tryandromeda/andromeda"
 version = "0.1.0"

--- a/core/src/extension.rs
+++ b/core/src/extension.rs
@@ -1,6 +1,6 @@
 use nova_vm::{
     ecmascript::{
-        builtins::{create_builtin_function, Behaviour, BuiltinFunctionArgs, RegularFn},
+        builtins::{Behaviour, BuiltinFunctionArgs, RegularFn, create_builtin_function},
         execution::Agent,
         scripts_and_modules::script::{parse_script, script_evaluation},
         types::{InternalMethods, IntoValue, Object, PropertyDescriptor, PropertyKey},
@@ -8,7 +8,7 @@ use nova_vm::{
     engine::context::GcScope,
 };
 
-use crate::{exit_with_parse_errors, HostData, OpsStorage};
+use crate::{HostData, OpsStorage, exit_with_parse_errors};
 
 pub type ExtensionStorageInit = Box<dyn FnOnce(&mut OpsStorage)>;
 

--- a/core/src/host_data.rs
+++ b/core/src/host_data.rs
@@ -3,9 +3,9 @@ use std::{
     collections::HashMap,
     future::Future,
     sync::{
+        Arc,
         atomic::{AtomicU32, Ordering},
         mpsc::{Receiver, Sender},
-        Arc,
     },
 };
 

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -10,8 +10,8 @@ use nova_vm::{
     ecmascript::{
         builtins::promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability,
         execution::{
-            agent::{GcAgent, HostHooks, Job, Options, RealmRoot},
             Agent, JsResult,
+            agent::{GcAgent, HostHooks, Job, Options, RealmRoot},
         },
         scripts_and_modules::script::{parse_script, script_evaluation},
         types::{self, Object, Value},
@@ -19,7 +19,7 @@ use nova_vm::{
     engine::context::GcScope,
 };
 
-use crate::{exit_with_parse_errors, Extension, HostData, MacroTask};
+use crate::{Extension, HostData, MacroTask, exit_with_parse_errors};
 
 pub struct RuntimeHostHooks<UserMacroTask> {
     pub(crate) promise_job_queue: RefCell<VecDeque<Job>>,

--- a/runtime/src/ext/console/mod.rs
+++ b/runtime/src/ext/console/mod.rs
@@ -1,4 +1,4 @@
-use std::io::{stdout, Write};
+use std::io::{Write, stdout};
 
 use andromeda_core::{Extension, ExtensionOp};
 use nova_vm::{

--- a/runtime/src/ext/fs.rs
+++ b/runtime/src/ext/fs.rs
@@ -1,13 +1,13 @@
 use std::{borrow::BorrowMut, fs::File};
 
 use nova_vm::{
+    SmallInteger,
     ecmascript::{
         builtins::ArgumentsList,
         execution::{Agent, JsResult},
         types::Value,
     },
     engine::context::GcScope,
-    SmallInteger,
 };
 
 use andromeda_core::{Extension, ExtensionOp, HostData, OpsStorage, ResourceTable};

--- a/runtime/src/ext/process.rs
+++ b/runtime/src/ext/process.rs
@@ -77,7 +77,9 @@ impl ProcessExt {
         let value = args.get(1);
         let value = value.to_string(agent, gc.reborrow())?;
 
-        env::set_var(key.as_str(agent), value.as_str(agent));
+        unsafe {
+            env::set_var(key.as_str(agent), value.as_str(agent));
+        }
 
         Ok(Value::Undefined)
     }
@@ -91,7 +93,9 @@ impl ProcessExt {
         let key = args.get(0);
         let key = key.to_string(agent, gc.reborrow())?;
 
-        env::remove_var(key.as_str(agent));
+        unsafe {
+            env::remove_var(key.as_str(agent));
+        }
 
         Ok(Value::Undefined)
     }

--- a/runtime/src/ext/time/interval.rs
+++ b/runtime/src/ext/time/interval.rs
@@ -1,8 +1,8 @@
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicU32, Ordering},
         Arc,
+        atomic::{AtomicU32, Ordering},
     },
     time::Duration,
 };

--- a/runtime/src/ext/time/mod.rs
+++ b/runtime/src/ext/time/mod.rs
@@ -6,13 +6,13 @@ use std::time::Duration;
 use nova_vm::{
     ecmascript::{
         builtins::{
-            promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability,
             ArgumentsList,
+            promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability,
         },
         execution::{Agent, JsResult},
         types::{IntoValue, Value},
     },
-    engine::{context::GcScope, Global},
+    engine::{Global, context::GcScope},
 };
 use tokio::time::interval;
 

--- a/runtime/src/ext/time/timeout.rs
+++ b/runtime/src/ext/time/timeout.rs
@@ -1,8 +1,8 @@
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicU32, Ordering},
         Arc,
+        atomic::{AtomicU32, Ordering},
     },
     time::Duration,
 };

--- a/runtime/src/ext/web/mod.rs
+++ b/runtime/src/ext/web/mod.rs
@@ -2,7 +2,7 @@ use andromeda_core::{Extension, ExtensionOp};
 use nova_vm::{
     ecmascript::{
         builtins::ArgumentsList,
-        execution::{agent::ExceptionType, Agent, JsResult},
+        execution::{Agent, JsResult, agent::ExceptionType},
         types::Value,
     },
     engine::context::{GcScope, NoGcScope},

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
I’ve upgraded Nova’s version as well, so let’s align this accordingly.

ref: 
- https://github.com/trynova/nova/pull/572
- https://github.com/trynova/nova/pull/576