### PR TITLE
feat(runtime): URL parse() static method

### DIFF
--- a/examples/url.ts
+++ b/examples/url.ts
@@ -10,7 +10,6 @@ console.log(B)
 
 console.log(new URL("en-US/docs", B)); // 'https://developer.mozilla.org/en-US/docs'
 
-
 const D = new URL("/en-US/docs", B); // 'https://developer.mozilla.org/en-US/docs'
 console.log(D)
 
@@ -19,3 +18,36 @@ console.log(new URL("/en-US/docs", D)); // 'https://developer.mozilla.org/en-US/
 console.log(new URL("/en-US/docs", A)); // 'https://developer.mozilla.org/en-US/docs'
 
 new URL("/en-US/docs", "https://developer.mozilla.org/fr-FR/toto"); // 'https://developer.mozilla.org/en-US/docs'
+
+// https://developer.mozilla.org/en-US/docs/Web/API/URL/parse_static#examples
+if ("parse" in URL) {
+    // Absolute URL
+    let result = URL.parse("https://developer.mozilla.org/en-US/docs");
+    console.log(`[1]: ${result}`);
+
+    // Relative reference to a valid base URL
+    result = URL.parse("en-US/docs", "https://developer.mozilla.org");
+    console.log(`[2]: ${result}`);
+
+    // Relative reference to a "complicated" valid base URL
+    // (only the scheme and domain are used to resolve url)
+    result = URL.parse(
+        "/different/place",
+        "https://developer.mozilla.org:443/some/path?id=4",
+    );
+    console.log(`[3]: ${result}`);
+
+    // Absolute url argument (base URL ignored)
+    result = URL.parse(
+        "https://example.org/some/docs",
+        "https://developer.mozilla.org",
+    );
+    console.log(`[4]: ${result}`);
+
+    // TODO: error is returned, but null should be returned here
+    // Invalid base URL (missing colon)
+    // result = URL.parse("en-US/docs", "https//developer.mozilla.org");
+    // console.log(`[5]: ${result}`);
+} else {
+    console.log("URL.parse() not supported");
+}

--- a/runtime/src/ext/url/mod.ts
+++ b/runtime/src/ext/url/mod.ts
@@ -1,5 +1,6 @@
 // deno-lint-ignore-file no-unused-vars
 class URL {
+    // TODO: Need to return a URL object. 
     constructor(url: string, base?: string) {
         // @ts-ignore - this is a hack to make the URL object work
         this.url = url;
@@ -14,5 +15,9 @@ class URL {
     toString() {
         // @ts-ignore - this is a hack to make the URL object work
         return this.serialized;
+    }
+
+    static parse(url: string, base?: string) {
+        return new this(url, base)
     }
 }


### PR DESCRIPTION
In reading deno, I found that this method is not as difficult as I thought. (https://github.com/denoland/deno/blob/b6b5c7d7d99f4f763fad87ee0f253d523ad49fc3/ext/url/00_url.js#L413-L431)
And the existing URL constructor returns a string, but I thought perhaps it would be nice to be able to return a URL object I'm adding to the TODO comment.