### PR TITLE
Forward compatibility with rust-lang/rust#138961

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap();
 
     // Run Nova in a secondary blocking thread so tokio tasks can still run
-    let nova_thread = rt.spawn_blocking(|| match args.command {
+    let nova_thread = rt.spawn_blocking(move || match args.command {
         Command::Run {
             verbose,
             no_strict,


### PR DESCRIPTION
The rustc development team is considering making some changes w.r.t. how closure captures interact with patterns. Technically, it is a breaking change – your project is the only one found by [Crater](https://rustc-dev-guide.rust-lang.org/tests/crater.html) to be broken by this change. For more details, see rust-lang/rust#138961.

This PR is to make your project be compatible with the new behavior of rustc ahead of the rustc PR landing, and reduce the disruption caused.