### PR TITLE
docs: update cargo install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ECMAScript standards and common runtime behaviors.
 Install Andromeda using Cargo:
 
 ```sh
-cargo install --git https://github.com/tryandromeda/andromeda
+cargo install --git https://github.com/tryandromeda/andromeda andromeda
 ```
 
 ### Running Code


### PR DESCRIPTION
The installation instructions are failing. It asks to specify a package.

```sh
≻ cargo install --git https://github.com/tryandromeda/andromeda
    Updating git repository `https://github.com/tryandromeda/andromeda`
    Updating git submodule `https://github.com/web-platform-tests/wpt.git`
error: multiple packages with binaries found: andromeda, tests. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/tryandromeda/andromeda andromeda`.
fatal: bad revision 'HEAD'
```
<img width="1156" height="109" alt="Screenshot 2025-09-28 at 3 40 32 PM" src="https://github.com/user-attachments/assets/25c3c02e-3d96-4a3a-8845-418005a28fa1" />
